### PR TITLE
fix: merge sort sorted_index must start at left, not 0

### DIFF
--- a/algorithms/sort/merge_sort.py
+++ b/algorithms/sort/merge_sort.py
@@ -1,5 +1,3 @@
-
-
 def merge(arr, left, middle, right):
     # The second param is non inclusive so it should be increased by one
     left_copy = arr[left: middle+1]
@@ -7,10 +5,9 @@ def merge(arr, left, middle, right):
 
     left_index = 0
     right_index = 0
-    sorted_index = 0
+    sorted_index = left  # must start at left, not 0
 
     while left_index < len(left_copy) and right_index < len(right_copy):
-        print(f'left_index= {left_index}, right_index= {right_index}, sortedindex= {sorted_index}, arr={arr}')
         if left_copy[left_index] < right_copy[right_index]:
             arr[sorted_index] = left_copy[left_index]
             left_index += 1
@@ -24,12 +21,14 @@ def merge(arr, left, middle, right):
         arr[sorted_index] = left_copy[left_index]
         left_index += 1
         sorted_index += 1
+
     while right_index < len(right_copy):
         arr[sorted_index] = right_copy[right_index]
         right_index += 1
         sorted_index += 1
 
     return arr
+
 
 def merge_sort(arr, left, right):
     if left < right:
@@ -39,6 +38,7 @@ def merge_sort(arr, left, right):
         merge(arr, left, middle, right)
     return arr
 
-array = [1,2,3,1,2,3]
 
-print(merge_sort(array, 0, len(array)-1))
+if __name__ == "__main__":
+    array = [1, 2, 3, 1, 2, 3]
+    print(merge_sort(array, 0, len(array)-1))


### PR DESCRIPTION
## Summary
- Fixes a bug where `sorted_index = 0` caused merged values to overwrite the beginning of `arr` instead of the correct subarray position
- Changed to `sorted_index = left` so writes go to the right place in the original array
- Also removed debug `print()` statement inside the merge loop
- Adds `if __name__ == "__main__"` guard