### PR TITLE
docs: add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Toolkit
-This is a repository where I use as a note book to store some brief pieces of code that perform general functionalities in Python or other languages.
+
+A personal notebook repository with brief code snippets covering general functionalities across Python and other languages.
+
+## Contents
+
+| Topic | Description |
+|-------|-------------|
+| [algorithms/](algorithms/) | Sorting, searching, recursion, divide & conquer |
+| [DS/](DS/) | Data structures |
+| [design_patterns/](design_patterns/) | Common design patterns |
+| [django2/](django2/) | Django framework examples |
+| [docker/](docker/) | Docker configuration snippets |
+| [go_lang/](go_lang/) | Go language examples |
+| [javascript/](javascript/) | JavaScript snippets |
+| [java_tutorial/](java_tutorial/) | Java examples |
+| [kubernetes_tutorial/](kubernetes_tutorial/) | Kubernetes configs |
+| [leetcode_problems/](leetcode_problems/) | LeetCode solutions |
+| [mysql/](mysql/) | MySQL queries |
+| [react/](react/) | React examples |
+| [rust/](rust/) | Rust snippets |
+| [sql/](sql/) | SQL queries |
+| [typescript/](typescript/) | TypeScript examples |
+| [testing.py](testing.py) | Python testing examples |
+| [threading/](threading/) | Python threading |
+| [decorator/](decorator/) | Python decorators |
+| [security_/](security_/) | Security-related snippets |


### PR DESCRIPTION
## Summary
- Expands the README from a single sentence to include a structured table of contents
- Links to all major topic directories for easier navigation