### PR TITLE
fix: fibonacci base case — fibo(0) should return 0, not 1

### DIFF
--- a/algorithms/divide_and_conquer/fibo.py
+++ b/algorithms/divide_and_conquer/fibo.py
@@ -1,9 +1,12 @@
 def fibo(n):
-    if n == 1:
-        return 1
-    elif n == 0:
+    if n == 0:
+        return 0
+    elif n == 1:
         return 1
     else:
-        return fibo(n-1) + fibo(n-2)
+        return fibo(n - 1) + fibo(n - 2)
 
-print(fibo(3))
+
+if __name__ == "__main__":
+    for i in range(8):
+        print(f"fibo({i}) = {fibo(i)}")


### PR DESCRIPTION
By convention fibo(0)=0, fibo(1)=1. The original had both return 1 which shifts the sequence. Also adds main guard with output for first 8 values.