### PR TITLE
feat: add memoized fibonacci using lru_cache

### DIFF
--- a/algorithms/divide_and_conquer/fibo_memoized.py
+++ b/algorithms/divide_and_conquer/fibo_memoized.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def fibo(n):
+    if n == 0:
+        return 0
+    elif n == 1:
+        return 1
+    return fibo(n - 1) + fibo(n - 2)
+
+
+if __name__ == "__main__":
+    for i in range(10):
+        print(f"fibo({i}) = {fibo(i)}")


### PR DESCRIPTION
Adds memoized version of fibonacci using `@lru_cache`. Reduces time from O(2^n) to O(n) by caching repeated subproblems.