### PR TITLE
feat: add group anagrams using hash map

### DIFF
--- a/algorithms/hash_map/group_anagrams.py
+++ b/algorithms/hash_map/group_anagrams.py
@@ -1,0 +1,13 @@
+from collections import defaultdict
+
+
+def group_anagrams(strs):
+    groups = defaultdict(list)
+    for word in strs:
+        key = tuple(sorted(word))
+        groups[key].append(word)
+    return list(groups.values())
+
+
+if __name__ == "__main__":
+    print(group_anagrams(["eat", "tea", "tan", "ate", "nat", "bat"]))


### PR DESCRIPTION
Groups strings that are anagrams of each other. Uses sorted tuple as hash key — O(n * k log k) where k is max string length.