### PR TITLE
feat: add LRU cache using OrderedDict

### DIFF
--- a/DS/lru_cache.py
+++ b/DS/lru_cache.py
@@ -1,0 +1,31 @@
+from collections import OrderedDict
+
+
+class LRUCache:
+    def __init__(self, capacity):
+        self.capacity = capacity
+        self.cache = OrderedDict()
+
+    def get(self, key):
+        if key not in self.cache:
+            return -1
+        self.cache.move_to_end(key)
+        return self.cache[key]
+
+    def put(self, key, value):
+        if key in self.cache:
+            self.cache.move_to_end(key)
+        self.cache[key] = value
+        if len(self.cache) > self.capacity:
+            self.cache.popitem(last=False)
+
+
+if __name__ == "__main__":
+    lru = LRUCache(3)
+    lru.put(1, 1)
+    lru.put(2, 2)
+    lru.put(3, 3)
+    print(lru.get(1))   # 1
+    lru.put(4, 4)       # evicts key 2
+    print(lru.get(2))   # -1 (evicted)
+    print(lru.get(3))   # 3


### PR DESCRIPTION
O(1) get and put using Python's OrderedDict which preserves insertion order. Evicts least recently used when capacity exceeded.