### PR TITLE
feat: add level order traversal (BFS) for binary tree

### DIFF
--- a/DS/tree/level_order_traversal.py
+++ b/DS/tree/level_order_traversal.py
@@ -1,0 +1,35 @@
+from collections import deque
+
+
+class Node:
+    def __init__(self, val):
+        self.val = val
+        self.left = None
+        self.right = None
+
+
+def level_order(root):
+    if not root:
+        return []
+    result = []
+    queue = deque([root])
+    while queue:
+        level = []
+        for _ in range(len(queue)):
+            node = queue.popleft()
+            level.append(node.val)
+            if node.left:
+                queue.append(node.left)
+            if node.right:
+                queue.append(node.right)
+        result.append(level)
+    return result
+
+
+if __name__ == "__main__":
+    root = Node(1)
+    root.left = Node(2)
+    root.right = Node(3)
+    root.left.left = Node(4)
+    root.left.right = Node(5)
+    print(level_order(root))   # [[1], [2, 3], [4, 5]]


### PR DESCRIPTION
Returns list of lists where each inner list contains nodes at that depth. Uses deque for O(n) traversal.