### PR TITLE
feat: add threading lock example

### DIFF
--- a/threading/threading_lock.py
+++ b/threading/threading_lock.py
@@ -1,0 +1,20 @@
+import threading
+
+counter = 0
+lock = threading.Lock()
+
+
+def increment(n):
+    global counter
+    for _ in range(n):
+        with lock:
+            counter += 1
+
+
+if __name__ == "__main__":
+    threads = [threading.Thread(target=increment, args=(1000,)) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    print(f"Final counter: {counter}")   # 5000 (not random without lock)


### PR DESCRIPTION
Shows how to use threading.Lock() with a context manager to safely increment a shared counter from multiple threads.